### PR TITLE
fix(bot): incorrect method of outging webhook for bots

### DIFF
--- a/src/routes/hook_route.ts
+++ b/src/routes/hook_route.ts
@@ -22,13 +22,20 @@ app.get('/unRegisterWebhook', async (c) => {
 	return new Response(r.ok ? 'Ok' : r.description ?? '')
 })
 
-app.get(WEBHOOK, async (c) => {
+app.post(WEBHOOK, async (c) => {
 	const update: Update = await c.req.json()
 	if (update.message && isMentioned(update.message)) {
 		const bot = createBot(c)
 		const ai = createOpenAI(c)
 		const tts = createTTS(c)
-		await translate(update.message, { bot, ai, tts })
+		try {
+			await translate(update.message, { bot, ai, tts })
+		} catch (error) {
+			await bot.sendMessage({
+				chat_id: update.message.chat.id,
+				text: `${error}`
+			})
+		}
 	}
 	return new Response('Ok')
 })


### PR DESCRIPTION
While refactoring by the hono framework(#1), a bug is introduced and breaks the worker.

The document of TelegramBotAPI has mentioned that the bot will [send an **HTTPS POST** request to the specified URL](https://core.telegram.org/bots/api#setwebhook), which is exactly recode into the **GET** method during the refactor.

This pull request is to fix the issue.